### PR TITLE
Optimize file reading by switching to stream-based comment filtering

### DIFF
--- a/showcases/src/test/java/org/example/ShowcaseCompilerTest.java
+++ b/showcases/src/test/java/org/example/ShowcaseCompilerTest.java
@@ -103,9 +103,12 @@ public class ShowcaseCompilerTest
     public void processShowcaseFile() throws IOException
     {
         // Stripping comments required as parser will remove them
-        String pureGrammar = Files.readAllLines(showcasePath).stream()
-                .filter(l -> !l.stripLeading().startsWith("//"))
+        String pureGrammar;
+        try (Stream<String> lines = Files.lines(showcasePath)) {
+            pureGrammar = lines
+                .filter(line -> !line.stripLeading().startsWith("//"))
                 .collect(Collectors.joining("\n"));
+        }
 
         assumeFalse(pureGrammar.isEmpty());
 


### PR DESCRIPTION
- Replaced `Files.readAllLines()` with `Files.lines()` to enable lazy loading, improving memory efficiency and performance, especially for large files.
- Added a try-with-resources block to ensure the stream is closed automatically after use.
- Streamlined comment filtering by processing lines directly and joining them into a single string without intermediate storage.

This optimization minimizes memory usage and enhances performance by avoiding the overhead of loading the entire file into memory at once.